### PR TITLE
[#155934507] Pass the isWebhookEnabled preference from app to API backend (and vice versa)

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -163,21 +163,23 @@ paths:
           description: Profile cannot be updated.
 definitions:
   MessageContent:
-    $ref: "https://raw.githubusercontent.com/teamdigitale/digital-citizenship-functions/3d315e4/api/definitions.yaml#MessageContent"
+    $ref: "https://raw.githubusercontent.com/teamdigitale/digital-citizenship-functions/v0.38.0/api/definitions.yaml#MessageContent"
   FiscalCode:
-    $ref: "https://raw.githubusercontent.com/teamdigitale/digital-citizenship-functions/3d315e4/api/definitions.yaml#FiscalCode"
+    $ref: "https://raw.githubusercontent.com/teamdigitale/digital-citizenship-functions/v0.38.0/api/definitions.yaml#FiscalCode"
   EmailAddress:
-    $ref: "https://raw.githubusercontent.com/teamdigitale/digital-citizenship-functions/3d315e4/api/definitions.yaml#EmailAddress"
+    $ref: "https://raw.githubusercontent.com/teamdigitale/digital-citizenship-functions/v0.38.0/api/definitions.yaml#EmailAddress"
   ExtendedProfile:
-    $ref: "https://raw.githubusercontent.com/teamdigitale/digital-citizenship-functions/3d315e4/api/definitions.yaml#ExtendedProfile"
+    $ref: "https://raw.githubusercontent.com/teamdigitale/digital-citizenship-functions/v0.38.0/api/definitions.yaml#ExtendedProfile"
   LimitedProfile:
-    $ref: "https://raw.githubusercontent.com/teamdigitale/digital-citizenship-functions/3d315e4/api/definitions.yaml#LimitedProfile"
+    $ref: "https://raw.githubusercontent.com/teamdigitale/digital-citizenship-functions/v0.38.0/api/definitions.yaml#LimitedProfile"
   PreferredLanguages:
-    $ref: "https://raw.githubusercontent.com/teamdigitale/digital-citizenship-functions/3d315e4/api/definitions.yaml#PreferredLanguages"
+    $ref: "https://raw.githubusercontent.com/teamdigitale/digital-citizenship-functions/v0.38.0/api/definitions.yaml#PreferredLanguages"
   IsInboxEnabled:
-    $ref: "https://raw.githubusercontent.com/teamdigitale/digital-citizenship-functions/3d315e4/api/definitions.yaml#IsInboxEnabled"
+    $ref: "https://raw.githubusercontent.com/teamdigitale/digital-citizenship-functions/v0.38.0/api/definitions.yaml#IsInboxEnabled"
+  IsWebhookEnabled:
+    $ref: "https://raw.githubusercontent.com/teamdigitale/digital-citizenship-functions/v0.38.0/api/definitions.yaml#IsWebhookEnabled"
   PaginationResponse:
-    $ref: "https://raw.githubusercontent.com/teamdigitale/digital-citizenship-functions/3d315e4/api/definitions.yaml#PaginationResponse"
+    $ref: "https://raw.githubusercontent.com/teamdigitale/digital-citizenship-functions/v0.38.0/api/definitions.yaml#PaginationResponse"
   Message:
     title: Message
     type: object
@@ -208,6 +210,8 @@ definitions:
         type: boolean
       is_inbox_enabled:
         $ref: "#/definitions/IsInboxEnabled"
+      is_webhook_enabled:
+        $ref: "#/definitions/IsWebhookEnabled"
       name:
         type: string
       preferred_email:

--- a/public/profile.html
+++ b/public/profile.html
@@ -28,6 +28,7 @@
   <div id="preferred_email"></div>
   <div id="version"></div>
   <div id="is_inbox_enabled"></div>
+  <div id="is_webhook_enabled"></div>
 
   <h2>Edit</h2>
 
@@ -36,6 +37,8 @@
     <input type="text" id="edit_email" value=""/><br/>
     <label for="edit_inbox_enabled">Inbox enabled:</label>
     <input type="checkbox" id="edit_inbox_enabled" checked/><br/>
+    <label for="edit_webhook_enabled">Webhook enabled:</label>
+    <input type="checkbox" id="edit_webhook_enabled" checked/><br/>
     <input type="hidden" id="edit_version" value=""/><br/>
     <input type="submit" name="Save">
   </form>
@@ -102,6 +105,14 @@
               $("#is_inbox_enabled").append("Inbox non enabled");
               $("#edit_inbox_enabled").attr("checked", false);
             }
+
+            if (data.is_webhook_enabled) {
+              $("#is_webhook_enabled").append("Webhook enabled");
+              $("#edit_webhook_enabled").attr("checked", true);
+            } else {
+              $("#is_webhook_enabled").append("Webhook non enabled");
+              $("#edit_webhook_enabled").attr("checked", false);
+            }
           });
         }
       )
@@ -114,6 +125,7 @@
 
   $("#edit").submit(function() {
     let data = {
+      isWebhookEnabled: $("#edit_webhook_enabled").is(":checked"),
       isInboxEnabled: $("#edit_inbox_enabled").is(":checked"),
       version: parseInt($("#edit_version").val())
     };

--- a/src/controllers/__tests__/profileController.test.ts
+++ b/src/controllers/__tests__/profileController.test.ts
@@ -7,6 +7,7 @@ import ProfileService from "../../services/profileService";
 import { EmailAddress } from "../../types/api/EmailAddress";
 import { FiscalCode } from "../../types/api/FiscalCode";
 import { IsInboxEnabled } from "../../types/api/IsInboxEnabled";
+import { IsWebhookEnabled } from "../../types/api/IsWebhookEnabled";
 import { PreferredLanguage } from "../../types/api/PreferredLanguages";
 import { ExtendedProfile } from "../../types/api_client/extendedProfile";
 import { User } from "../../types/user";
@@ -17,6 +18,7 @@ const aTimestamp = 1518010929530;
 const aFiscalNumber = "GRBGPP87L04L741X" as FiscalCode;
 const anEmailAddress = "garibaldi@example.com" as EmailAddress;
 const anIsInboxEnabled = true as IsInboxEnabled;
+const anIsWebookEnabled = true as IsWebhookEnabled;
 const aPreferredLanguage = "it_IT" as PreferredLanguage;
 const aValidSpidLevel = "https://www.spid.gov.it/SpidL2";
 
@@ -26,6 +28,7 @@ const proxyUserResponse = {
   family_name: "Garibaldi",
   fiscal_code: aFiscalNumber,
   isInboxEnabled: anIsInboxEnabled,
+  isWebhookEnabled: anIsWebookEnabled,
   name: "Giuseppe Maria",
   nameID: "garibaldi",
   nameIDFormat: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
@@ -56,6 +59,7 @@ const mockedUser: User = {
 const mockedUpsertUser: ExtendedProfile = {
   email: anEmailAddress,
   isInboxEnabled: anIsInboxEnabled,
+  isWebhookEnabled: anIsWebookEnabled,
   preferredLanguages: aPreferredLanguage,
   version: 1 as number
 };

--- a/src/services/__tests__/profileService.test.ts
+++ b/src/services/__tests__/profileService.test.ts
@@ -48,6 +48,7 @@ const proxyProfileWithoutEmailResponse = {
 const proxyUpsertRequest = {
   email: aValidAPIEmail,
   is_inbox_enabled: true,
+  is_webhook_enabled: true,
   preferred_languages: ["it_IT"],
   version: 42
 };
@@ -55,6 +56,7 @@ const ApiProfileUpsertRequest = {
   body: {
     email: aValidAPIEmail,
     is_inbox_enabled: true,
+    is_webhook_enabled: true,
     preferred_languages: ["it_IT"],
     version: 42
   }

--- a/src/types/__tests__/profile.test.ts
+++ b/src/types/__tests__/profile.test.ts
@@ -54,6 +54,7 @@ const mockedUser: User = {
 const mockedExtendedProfile: ExtendedProfile = {
   email: anEmailAddress,
   isInboxEnabled: anIsInboxEnabled,
+  isWebhookEnabled: anIsWebhookEnabled,
   preferredLanguages: aPreferredLanguage,
   version: 1 as number
 };
@@ -74,6 +75,9 @@ describe("profile type", () => {
     expect(userData.is_email_set).toBeTruthy();
     expect(userData.is_inbox_enabled).toBe(
       mockedGetProfileOKResponse.isInboxEnabled
+    );
+    expect(userData.is_webhook_enabled).toBe(
+      mockedGetProfileOKResponse.isWebhookEnabled
     );
     expect(userData.name).toBe(mockedUser.name);
     expect(userData.preferred_email).toBe(mockedUser.preferred_email);

--- a/src/types/api_client/extendedProfile.ts
+++ b/src/types/api_client/extendedProfile.ts
@@ -6,6 +6,7 @@ import * as t from "io-ts";
 import { number } from "io-ts";
 import { EmailAddress } from "../api/EmailAddress";
 import { IsInboxEnabled } from "../api/IsInboxEnabled";
+import { IsWebhookEnabled } from "../api/IsWebhookEnabled";
 import { PreferredLanguage } from "../api/PreferredLanguages";
 
 // required attributes
@@ -15,6 +16,7 @@ const ExtendedProfileR = t.interface({});
 const ExtendedProfileO = t.partial({
   email: EmailAddress,
   isInboxEnabled: IsInboxEnabled,
+  isWebhookEnabled: IsWebhookEnabled,
   preferredLanguages: PreferredLanguage,
   version: number
 });


### PR DESCRIPTION
Adds isWebhookEnabled to all required types
Points the swagger definitions to a tag instead of a commit