### PR TITLE
Fix autorest typescript extension to a know version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "prettify": "prettier --write './**/*.ts'",
     "test": "jest -i",
     "start": "node src/server.js",
-    "generate-api-client": "swagger-cli bundle https://raw.githubusercontent.com/teamdigitale/digital-citizenship-functions/v0.38.0/api/public_api_v1.yaml | autorest --typescript --input-file=/dev/stdin --output-folder=src/api --add-credentials"
+    "generate-api-client": "swagger-cli bundle https://raw.githubusercontent.com/teamdigitale/digital-citizenship-functions/v0.38.0/api/public_api_v1.yaml | autorest --typescript --input-file=/dev/stdin --output-folder=src/api --add-credentials --use=@microsoft.azure/autorest.typescript@2.0.176"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
As mentioned [here](https://github.com/Azure/autorest.typescript/issues/80) by default Autorest uses the latest version for the extensions used to perform the client generation. It could happens that the extension's version is out of sync and this could cause generation failures.

This PR is aimed to fix the extension version of the typescript generator