### PR TITLE
Bump to version 0.0.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "italia-backend",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "Italia app and web backend",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
This version introduce the `create_at` field for messages and it is needed by the APP to correctly generate type definitions