### PR TITLE
Add makefile with building steps.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+#
+# A simple makefile to run all building tasks.
+# 
+#
+
+all:
+
+	scripts/build-tools.sh  		#  to build the `tools` Docker image
+	scripts/yarn.sh  			#  to install backend dependencies
+	scripts/generate-proxy-api-models.sh  	#  to generate the models defined in api_proxy.yaml and api_notifications.yaml
+	scripts/generate-api-client.sh  	#  to generate the Autorest API Client
+	scripts/build.sh  			#  to compile the Typescript files
+	docker-compose up -d  			#  to start the containers


### PR DESCRIPTION
## I wish

To build the project without typing all commands

## How it's implemented?

Just a Makefile with all the commands defined in the README.md

## What next

We could move out of the README.md the commands and reference the Makefile.