### PR TITLE
[#158998658] Return 200 on /logout

### DIFF
--- a/src/controllers/__tests__/authenticationController.test.ts
+++ b/src/controllers/__tests__/authenticationController.test.ts
@@ -305,14 +305,10 @@ describe("AuthenticationController#logout", () => {
     jest.resetAllMocks();
   });
 
-  it("extracts the logout url", async () => {
+  it("shoud return success after deleting the session token", async () => {
     const res = mockRes();
     const req = mockReq();
     req.user = mockedUser;
-
-    spidStrategyInstance.logout.mockImplementation((_: any, callback: any) => {
-      callback(undefined, "http://www.example.com");
-    });
 
     mockDel.mockReturnValue(Promise.resolve(right(true)));
 
@@ -321,8 +317,11 @@ describe("AuthenticationController#logout", () => {
 
     expect(controller).toBeTruthy();
     expect(mockDel).toHaveBeenCalledWith(mockSessionToken, mockWalletToken);
-    expect(spidStrategyInstance.logout.mock.calls[0][0]).toBe(req);
-    expect(res.redirect).toHaveBeenCalledWith("http://www.example.com", 301);
+    expect(response).toEqual({
+      apply: expect.any(Function),
+      kind: "IResponseSuccessJson",
+      value: { message: "ok" }
+    });
   });
 
   it("should fail if the generation user data is invalid", async () => {
@@ -342,32 +341,7 @@ describe("AuthenticationController#logout", () => {
     });
   });
 
-  it("should fail if the generation of logout fails", async () => {
-    const res = mockRes();
-    const req = mockReq();
-    req.user = mockedUser;
-
-    spidStrategyInstance.logout.mockImplementation(
-      (_: any, callback: (error: Error) => void) => {
-        callback(new Error("Error message"));
-      }
-    );
-
-    mockDel.mockReturnValue(Promise.resolve(right(true)));
-
-    const response = await controller.logout(req);
-    response.apply(res);
-
-    expect(controller).toBeTruthy();
-    expect(mockDel).toHaveBeenCalledWith(mockSessionToken, mockWalletToken);
-    expect(res.status).toHaveBeenCalledWith(500);
-    expect(res.json).toHaveBeenCalledWith({
-      ...anErrorResponse,
-      detail: "Error message"
-    });
-  });
-
-  it("should fail if the session can not be saved", async () => {
+  it("should fail if the session can not be destroyed", async () => {
     const res = mockRes();
     const req = mockReq();
     req.user = mockedUser;
@@ -380,7 +354,7 @@ describe("AuthenticationController#logout", () => {
     expect(res.status).toHaveBeenCalledWith(500);
     expect(res.json).toHaveBeenCalledWith({
       ...anErrorResponse,
-      detail: "Error creating the user session"
+      detail: "Error destroying the user session"
     });
   });
 

--- a/src/controllers/authenticationController.ts
+++ b/src/controllers/authenticationController.ts
@@ -19,6 +19,7 @@ import {
 import { UrlFromString } from "italia-ts-commons/lib/url";
 import { ISessionStorage } from "../services/ISessionStorage";
 import TokenService from "../services/tokenService";
+import { SuccessResponse } from "../types/commons";
 import { SessionToken, WalletToken } from "../types/token";
 import {
   extractUserFromRequest,
@@ -79,7 +80,7 @@ export default class AuthenticationController {
    */
   public async logout(
     req: express.Request
-  ): Promise<IResponseErrorInternal | IResponseSuccessJson<{}>> {
+  ): Promise<IResponseErrorInternal | IResponseSuccessJson<SuccessResponse>> {
     const errorOrUser = extractUserFromRequest(req);
 
     if (isLeft(errorOrUser)) {
@@ -102,10 +103,10 @@ export default class AuthenticationController {
     const response = errorOrResponse.value;
 
     if (!response) {
-      return ResponseErrorInternal("Error creating the user session");
+      return ResponseErrorInternal("Error destroying the user session");
     }
 
-    return ResponseSuccessJson({});
+    return ResponseSuccessJson({ message: "ok" });
   }
 
   /**

--- a/src/controllers/authenticationController.ts
+++ b/src/controllers/authenticationController.ts
@@ -9,9 +9,11 @@ import { isLeft } from "fp-ts/lib/Either";
 import {
   IResponseErrorInternal,
   IResponsePermanentRedirect,
+  IResponseSuccessJson,
   IResponseSuccessXml,
   ResponseErrorInternal,
   ResponsePermanentRedirect,
+  ResponseSuccessJson,
   ResponseSuccessXml
 } from "italia-ts-commons/lib/responses";
 import { UrlFromString } from "italia-ts-commons/lib/url";
@@ -77,7 +79,7 @@ export default class AuthenticationController {
    */
   public async logout(
     req: express.Request
-  ): Promise<IResponseErrorInternal | IResponsePermanentRedirect> {
+  ): Promise<IResponseErrorInternal | IResponseSuccessJson<{}>> {
     const errorOrUser = extractUserFromRequest(req);
 
     if (isLeft(errorOrUser)) {
@@ -103,15 +105,7 @@ export default class AuthenticationController {
       return ResponseErrorInternal("Error creating the user session");
     }
 
-    // Logout from SPID.
-    // The logout function in spid-passport expects an entityID attribute
-    // passed in the query string. Here we recover the IDP chosen for the
-    // login (and stored in the User object) to forge a request suitable
-    // for the login function.
-    req.query = {};
-    req.query.entityID = user.spid_idp;
-
-    return this.spidLogout(req);
+    return ResponseSuccessJson({});
   }
 
   /**
@@ -134,26 +128,5 @@ export default class AuthenticationController {
     );
 
     return ResponseSuccessXml(metadata);
-  }
-
-  /**
-   * Wrap the spidStrategy.logout function in a new Promise.
-   */
-  private spidLogout(
-    req: express.Request
-  ): Promise<IResponseErrorInternal | IResponsePermanentRedirect> {
-    return new Promise(resolve => {
-      this.spidStrategy.logout(req, (err, logoutUrl) => {
-        if (!err) {
-          const url: UrlFromString = {
-            href: logoutUrl
-          };
-
-          return resolve(ResponsePermanentRedirect(url));
-        } else {
-          return resolve(ResponseErrorInternal(err.message));
-        }
-      });
-    });
   }
 }

--- a/src/controllers/notificationController.ts
+++ b/src/controllers/notificationController.ts
@@ -14,7 +14,7 @@ import NotificationService from "../services/notificationService";
 import { Installation } from "../types/api/Installation";
 import { InstallationID } from "../types/api/InstallationID";
 import { Notification } from "../types/api/Notification";
-import { SuccessResponse } from "../types/notification";
+import { SuccessResponse } from "../types/commons";
 import { extractUserFromRequest } from "../types/user";
 import { log } from "../utils/logger";
 

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -16,10 +16,10 @@ import Response = Azure.ServiceBus.Response;
 import { InstallationID } from "../types/api/InstallationID";
 import { Notification } from "../types/api/Notification";
 import { PlatformEnum } from "../types/api/Platform";
+import { SuccessResponse } from "../types/commons";
 import {
   IInstallation,
   INotificationTemplate,
-  SuccessResponse,
   toFiscalCodeHash
 } from "../types/notification";
 

--- a/src/types/commons.ts
+++ b/src/types/commons.ts
@@ -1,0 +1,11 @@
+/**
+ * Common response message type.
+ */
+
+import * as t from "io-ts";
+
+export const SuccessResponse = t.interface({
+  message: t.string
+});
+
+export type SuccessResponse = t.TypeOf<typeof SuccessResponse>;

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -64,12 +64,3 @@ export const toFiscalCodeHash = (fiscalCode: FiscalCode): FiscalCodeHash => {
 
   return hash.digest("hex") as FiscalCodeHash;
 };
-
-/**
- * Common response message type.
- */
-export const SuccessResponse = t.interface({
-  message: t.string
-});
-
-export type SuccessResponse = t.TypeOf<typeof SuccessResponse>;


### PR DESCRIPTION
Actually the Backend redirect the user to the IDP Logout page causing the APP to fail when making the request to `/logout`. We already discussed that we don't need to perform the real IDP Logout because the IDP Session timeout after 15 minutes. This PR make the Backend return 200 with an empty body object.