### PR TITLE
[#159519359] Remove conn retry on error 500 + Add a whitelist for errors to forward

### DIFF
--- a/src/services/pagoPAClientFactory.ts
+++ b/src/services/pagoPAClientFactory.ts
@@ -7,6 +7,7 @@
 
 import { ProxyPagoPA } from "../clients/pagopa/proxyPagoPA";
 import { IPagoPAClientFactoryInterface } from "./IPagoPAClientFactory";
+import { ServiceClientOptions } from "../../node_modules/ms-rest-js";
 
 export default class PagoPAClientFactory
   implements IPagoPAClientFactoryInterface {
@@ -18,10 +19,15 @@ export default class PagoPAClientFactory
     codiceContestoPagamento: string,
     rptIdFromString: string
   ): ProxyPagoPA {
+    // Avoid to retry to send the request if proxy reply with a 500 HTTP code
+    const serviceClientOptions = {
+      noRetryPolicy: true
+    } as ServiceClientOptions;
     return new ProxyPagoPA(
       codiceContestoPagamento,
       rptIdFromString,
-      this.pagoPAApiUrl
+      this.pagoPAApiUrl,
+      serviceClientOptions
     );
   }
 }

--- a/src/services/pagoPAClientFactory.ts
+++ b/src/services/pagoPAClientFactory.ts
@@ -5,9 +5,9 @@
  * @see ../clients/pagopa/PagoPAClientFactory
  */
 
+import { ServiceClientOptions } from "../../node_modules/ms-rest-js";
 import { ProxyPagoPA } from "../clients/pagopa/proxyPagoPA";
 import { IPagoPAClientFactoryInterface } from "./IPagoPAClientFactory";
-import { ServiceClientOptions } from "../../node_modules/ms-rest-js";
 
 export default class PagoPAClientFactory
   implements IPagoPAClientFactoryInterface {

--- a/src/services/pagoPAClientFactory.ts
+++ b/src/services/pagoPAClientFactory.ts
@@ -19,10 +19,9 @@ export default class PagoPAClientFactory
     codiceContestoPagamento: string,
     rptIdFromString: string
   ): ProxyPagoPA {
-    // Avoid to retry to send the request if proxy reply with a 500 HTTP code
-    const serviceClientOptions = {
-      noRetryPolicy: true
-    } as ServiceClientOptions;
+    const serviceClientOptions: ServiceClientOptions = {
+      noRetryPolicy: true // If set to true, turn off the default retry policy
+    };
     return new ProxyPagoPA(
       codiceContestoPagamento,
       rptIdFromString,

--- a/src/services/pagoPAProxyService.ts
+++ b/src/services/pagoPAProxyService.ts
@@ -2,7 +2,9 @@
  * TODO
  */
 
-import { Either, left, right } from "fp-ts/lib/Either";
+import { Either, isRight, left, right } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import { HttpOperationResponse } from "../../node_modules/ms-rest-js";
 import {
   PaymentActivationsGetResponse,
   PaymentActivationsPostRequest,
@@ -16,6 +18,19 @@ import { IPagoPAClientFactoryInterface } from "./IPagoPAClientFactory";
 
 const notFoundErrorMessage = "Payment info not found.";
 const internalErrorMessage = "Internal error.";
+
+/**
+ * WhiteList for Error Messages retrieved from PagoPaProxy to forward to CdApp
+ * A complete list of error mapping is available at:
+ * https://docs.google.com/document/d/1Qqe6mSfon-blHzc-ldeEHmzIkVaElKY5LtDnKiLbk80
+ */
+const pagoPaErrorWhiteList: ReadonlyArray<string> = [
+  "PAYMENT_UNAVAILABLE",
+  "INVALID_AMOUNT",
+  "PAYMENT_COMPLETED",
+  "PAYMENT_ONGOING",
+  "PAYMENT_EXPIRED"
+];
 
 export default class PagoPAProxyService {
   constructor(private readonly pagoPAClient: IPagoPAClientFactoryInterface) {}
@@ -38,7 +53,8 @@ export default class PagoPAProxyService {
       }
 
       if (simpleResponse.isInternalError()) {
-        return left(internalError(internalErrorMessage));
+        const errorMessage = getErrorMessageForApp(response);
+        return left(internalError(errorMessage));
       }
 
       return right(simpleResponse.parsedBody());
@@ -104,4 +120,36 @@ export default class PagoPAProxyService {
       return left(internalError(error.message));
     }
   }
+}
+
+/**
+ * Interface used to check if an http response has a custom title
+ */
+const ErrorBodyWithTitle = t.interface({
+  parsedBody: t.interface({
+    title: t.string
+  })
+});
+type ErrorBodyWithTitle = t.TypeOf<typeof ErrorBodyWithTitle>;
+
+/**
+ * Determine the error message to send to CDApp using a whitelist or a generic internal message
+ * Check Error Mapping documentation at:
+ * https://docs.google.com/document/d/1Qqe6mSfon-blHzc-ldeEHmzIkVaElKY5LtDnKiLbk80/edit#
+ */
+export function getErrorMessageForApp(
+  httpOperationResponse: HttpOperationResponse | undefined
+): string {
+  const errorBodyWithTitleOrError = ErrorBodyWithTitle.decode(
+    httpOperationResponse
+  );
+  if (isRight(errorBodyWithTitleOrError)) {
+    const bodyWithTitleOrError = errorBodyWithTitleOrError.value;
+    if (
+      pagoPaErrorWhiteList.indexOf(bodyWithTitleOrError.parsedBody.title) !== -1
+    ) {
+      return errorBodyWithTitleOrError.value.parsedBody.title;
+    }
+  }
+  return internalErrorMessage;
 }


### PR DESCRIPTION
When PagoPaProxy provides a specific error 500, Backend uses a whitelist to check if the error should be forwarded to applicant