### PR TITLE
[#159817292] [WIP] Create a single Profile type with separate spid_data and cd_data

### DIFF
--- a/api_proxy.yaml
+++ b/api_proxy.yaml
@@ -171,9 +171,7 @@ paths:
         "200":
           description: Found.
           schema:
-            allOf:
-              - $ref: "#/definitions/ProfileWithEmail"
-              - $ref: "#/definitions/ProfileWithoutEmail"
+              $ref: "#/definitions/Profile"
           examples:
             application/json:
               family_name: "Rossi"
@@ -212,7 +210,7 @@ paths:
         '200':
           description: Profile updated.
           schema:
-            $ref: "#/definitions/ProfileWithEmail"
+            $ref: "#/definitions/Profile"
           examples:
             application/json:
               email: foobar@example.com
@@ -488,27 +486,27 @@ definitions:
     required:
       - platform
       - pushChannel
-  ProfileWithEmail:
+
+  Profile:
     type: object
-    title: Profile with wmail
-    description: Describes the user's profile.
+    title: Profile
+    description: Profile
     properties:
-      blocked_inbox_or_channels:
-        $ref: "#/definitions/BlockedInboxOrChannels"
-      email:
-        $ref: '#/definitions/EmailAddress'
+      spid_data:
+        $ref: "#/definitions/ProfileSpidData"
+      cd_data:
+        $ref: "https://raw.githubusercontent.com/teamdigitale/digital-citizenship-functions/v0.51.0/api/definitions.yaml#/ExtendedProfile"
+    required:
+      - spid_data
+  ProfileSpidData:
+    type: object
+    title: Profile SPID data
+    description: Describes the user's profile SPID data.
+    properties:
       family_name:
         type: string
       fiscal_code:
         $ref: '#/definitions/FiscalCode'
-      has_profile:
-        $ref: "#/definitions/HasProfile"
-      is_email_set:
-        $ref: "#/definitions/IsEmailSet"
-      is_inbox_enabled:
-        $ref: "#/definitions/IsInboxEnabled"
-      is_webhook_enabled:
-        $ref: "#/definitions/IsWebhookEnabled"
       name:
         type: string
       spid_email:
@@ -516,64 +514,12 @@ definitions:
       spid_mobile_phone:
         type: string
         minLength: 1
-      preferred_languages:
-        type: array
-        items:
-          $ref: '#/definitions/PreferredLanguage'
-      version:
-        $ref: '#/definitions/Version'
     required:
       - family_name
       - fiscal_code
-      - has_profile
-      - is_email_set
-      - is_inbox_enabled
-      - is_webhook_enabled
       - name
       - spid_email
       - spid_mobile_phone
-      - version
-  ProfileWithoutEmail:
-    type: object
-    title: Profile without email
-    description: Describes the user's profile.
-    properties:
-      family_name:
-        type: string
-      fiscal_code:
-        $ref: '#/definitions/FiscalCode'
-      has_profile:
-        $ref: "#/definitions/HasProfile"
-      is_email_set:
-        $ref: "#/definitions/IsEmailSet"
-      is_inbox_enabled:
-        $ref: "#/definitions/IsInboxEnabled"
-      is_webhook_enabled:
-        $ref: "#/definitions/IsWebhookEnabled"
-      name:
-        type: string
-      spid_email:
-        $ref: '#/definitions/EmailAddress'
-      spid_mobile_phone:
-        type: string
-        minLength: 1
-      preferred_languages:
-        type: array
-        items:
-          $ref: '#/definitions/PreferredLanguage'
-      version:
-        $ref: '#/definitions/Version'
-    required:
-      - family_name
-      - fiscal_code
-      - has_profile
-      - is_email_set
-      - is_inbox_enabled
-      - is_webhook_enabled
-      - name
-      - spid_email
-      - spid_mobile_phone
-      - version
   PublicSession:
     type: object
     title: User session data

--- a/src/controllers/pagoPAController.ts
+++ b/src/controllers/pagoPAController.ts
@@ -1,16 +1,16 @@
 /**
  * This controller handles requests made from the PagoPA backend.
  */
-
 import * as express from "express";
 import { isLeft } from "fp-ts/lib/Either";
 import {
   ResponseErrorInternal,
   ResponseSuccessJson
 } from "italia-ts-commons/lib/responses";
+
 import ProfileService, { profileResponse } from "../services/profileService";
 import { PagoPAUser } from "../types/api/PagoPAUser";
-import { ProfileWithEmail } from "../types/api/ProfileWithEmail";
+import { Profile } from "../types/api/Profile";
 import { toHttpError } from "../types/error";
 import { extractUserFromRequest } from "../types/user";
 
@@ -41,10 +41,13 @@ export default class PagoPAController {
     }
 
     const profile = errorOrProfile.value;
-    const maybeCustomEmail = ProfileWithEmail.is(profile)
-      ? profile.email
-      : undefined;
-    const email = maybeCustomEmail ? maybeCustomEmail : profile.spid_email;
+    const maybeCustomEmail =
+      Profile.is(profile) && profile.cd_data
+        ? profile.cd_data.email
+        : undefined;
+    const email = maybeCustomEmail
+      ? maybeCustomEmail
+      : profile.spid_data.spid_email;
 
     return ResponseSuccessJson({
       email,

--- a/src/controllers/profileController.ts
+++ b/src/controllers/profileController.ts
@@ -2,7 +2,6 @@
  * This controller handles reading the user profile from the
  * app by forwarding the call to the API system.
  */
-
 import * as express from "express";
 import { isLeft } from "fp-ts/lib/Either";
 import {
@@ -11,9 +10,9 @@ import {
   ResponseErrorValidation,
   ResponseSuccessJson
 } from "italia-ts-commons/lib/responses";
+
 import ProfileService, { profileResponse } from "../services/profileService";
-import { ProfileWithEmail } from "../types/api/ProfileWithEmail";
-import { ProfileWithoutEmail } from "../types/api/ProfileWithoutEmail";
+import { Profile } from "../types/api/Profile";
 import { toHttpError } from "../types/error";
 import {
   extractUpsertProfileFromRequest,
@@ -34,7 +33,7 @@ export default class ProfileController {
    */
   public async getProfile(
     req: express.Request
-  ): Promise<profileResponse<ProfileWithoutEmail | ProfileWithEmail>> {
+  ): Promise<profileResponse<Profile>> {
     const errorOrUser = extractUserFromRequest(req);
 
     if (isLeft(errorOrUser)) {
@@ -61,7 +60,7 @@ export default class ProfileController {
    */
   public async upsertProfile(
     req: express.Request
-  ): Promise<profileResponseWithValidationError<ProfileWithEmail>> {
+  ): Promise<profileResponseWithValidationError<Profile>> {
     const errorOrUser = extractUserFromRequest(req);
 
     if (isLeft(errorOrUser)) {

--- a/src/services/__tests__/profileService.test.ts
+++ b/src/services/__tests__/profileService.test.ts
@@ -37,31 +37,32 @@ const validApiProfileResponse = {
   }
 };
 const proxyProfileWithEmailResponse = {
-  email: aValidAPIEmail,
-  family_name: "Lusso",
-  fiscal_code: "XUZTCT88A51Y311X",
-  has_profile: true,
-  is_email_set: true,
-  is_inbox_enabled: true,
-  is_webhook_enabled: true,
-  name: "Luca",
-  preferred_languages: ["it_IT"],
-  spid_email: aValidSPIDEmail,
-  spid_mobile_phone: "3222222222222",
-  version: 42
+  cd_data: {
+    email: aValidAPIEmail,
+    is_inbox_enabled: true,
+    is_webhook_enabled: true,
+    preferred_languages: ["it_IT"],
+    version: 42
+  },
+  spid_data: {
+    family_name: "Lusso",
+    fiscal_code: "XUZTCT88A51Y311X",
+    name: "Luca",
+    spid_email: aValidSPIDEmail,
+    spid_mobile_phone: "3222222222222"
+  }
 };
+
 const proxyProfileWithoutEmailResponse = {
-  family_name: "Lusso",
-  fiscal_code: aValidFiscalCode,
-  has_profile: false,
-  is_email_set: false,
-  is_inbox_enabled: false,
-  is_webhook_enabled: false,
-  name: "Luca",
-  spid_email: aValidSPIDEmail,
-  spid_mobile_phone: "3222222222222",
-  version: 0
+  spid_data: {
+    family_name: "Lusso",
+    fiscal_code: "XUZTCT88A51Y311X",
+    name: "Luca",
+    spid_email: aValidSPIDEmail,
+    spid_mobile_phone: "3222222222222"
+  }
 };
+
 const proxyUpsertRequest = {
   email: aValidAPIEmail,
   is_inbox_enabled: anIsInboxEnabled,

--- a/src/types/__tests__/profile.test.ts
+++ b/src/types/__tests__/profile.test.ts
@@ -18,8 +18,8 @@ import { Version } from "../api/Version";
 import { GetProfileOKResponse } from "../api_client/getProfileOKResponse";
 import {
   extractUpsertProfileFromRequest,
-  toAppProfileWithEmail,
-  toAppProfileWithoutEmail
+  toAppProfileWithCDData,
+  toProfileWithoutCDData
 } from "../profile";
 import { SessionToken, WalletToken } from "../token";
 import { User } from "../user";
@@ -66,47 +66,44 @@ const mockedExtendedProfile: ExtendedProfile = {
 };
 
 describe("profile type", () => {
+  /*test case: Converts an empty API profile to a Proxy profile using only the user data extracted from SPID.*/
+  it("should get an app Proxy profile without email from user data extracted from SPID", async () => {
+    // validate SpidUser. Return right.
+    const userData = toProfileWithoutCDData(
+      mockedUser // user
+    );
+
+    expect(userData).toEqual({
+      spid_data: {
+        family_name: mockedUser.family_name,
+        fiscal_code: mockedUser.fiscal_code,
+        name: mockedUser.name,
+        spid_email: mockedUser.spid_email,
+        spid_mobile_phone: mockedUser.spid_mobile_phone
+      }
+    });
+  });
+
   /*test case: Converts an existing API profile to a Proxy profile using user profile with email from Digital Citzen API and SPID*/
   it("should get an app Proxy profile user profile with email from Digital Citzen API and SPID", async () => {
     // return app Proxy Profile.
-    const userData = toAppProfileWithEmail(
+    const userData = toAppProfileWithCDData(
       mockedGetProfileOKResponse, // from
       mockedUser // user
     );
 
-    expect(userData.email).toBe(mockedGetProfileOKResponse.email);
-    expect(userData.family_name).toBe(mockedUser.family_name);
-    expect(userData.fiscal_code).toBe(mockedUser.fiscal_code);
-    expect(userData.has_profile).toBeTruthy();
-    expect(userData.is_email_set).toBeTruthy();
-    expect(userData.is_inbox_enabled).toBe(
-      mockedGetProfileOKResponse.isInboxEnabled
-    );
-    expect(userData.is_webhook_enabled).toBe(
-      mockedGetProfileOKResponse.isWebhookEnabled
-    );
-    expect(userData.name).toBe(mockedUser.name);
-    expect(userData.spid_email).toBe(mockedUser.spid_email);
-    expect(userData.preferred_languages).toBe(
-      mockedGetProfileOKResponse.preferredLanguages
-    );
-    expect(userData.version).toBe(mockedGetProfileOKResponse.version);
-  });
-
-  /*test case: Converts an empty API profile to a Proxy profile using only the user data extracted from SPID.*/
-  it("should get an app Proxy profile without email from user data extracted from SPID", async () => {
-    // validate SpidUser. Return right.
-    const userData = toAppProfileWithoutEmail(
-      mockedUser // user
-    );
-
-    expect(userData.family_name).toBe(mockedUser.family_name);
-    expect(userData.fiscal_code).toBe(mockedUser.fiscal_code);
-    expect(userData.has_profile).toBeFalsy();
-    expect(userData.is_email_set).toBeFalsy();
-
-    expect(userData.spid_email).toBe(mockedUser.spid_email);
-    expect(userData.version).toBe(0);
+    expect(userData).toEqual({
+      ...toProfileWithoutCDData(mockedUser),
+      cd_data: {
+        blocked_inbox_or_channels:
+          mockedGetProfileOKResponse.blockedInboxOrChannels,
+        email: mockedGetProfileOKResponse.email,
+        is_inbox_enabled: mockedGetProfileOKResponse.isInboxEnabled,
+        is_webhook_enabled: mockedGetProfileOKResponse.isWebhookEnabled,
+        preferred_languages: mockedGetProfileOKResponse.preferredLanguages,
+        version: mockedGetProfileOKResponse.version
+      }
+    });
   });
 
   /*test case: Extracts a user profile from the body of a request.*/

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -2,17 +2,32 @@
  * This file contains the ProfileWithEmail and ProfileWithoutEmail models and
  * some functions to validate and convert type to and from them.
  */
-
-import { Either } from "fp-ts/lib/Either";
-import { User } from "./user";
-
 import * as express from "express";
+import { Either } from "fp-ts/lib/Either";
+
 import { ExtendedProfile as proxyExtendedProfile } from "./api/ExtendedProfile";
-import { ProfileWithEmail } from "./api/ProfileWithEmail";
-import { ProfileWithoutEmail } from "./api/ProfileWithoutEmail";
-import { Version } from "./api/Version";
+import { Profile } from "./api/Profile";
 import { ExtendedProfile as apiExtendedProfile } from "./api_client/extendedProfile";
 import { GetProfileOKResponse } from "./api_client/getProfileOKResponse";
+import { User } from "./user";
+
+/**
+ * Converts an empty API profile to a Proxy profile.
+ *
+ * @param {User} user The user data extracted from SPID.
+ */
+export function toProfileWithoutCDData(user: User): Profile {
+  // We only returns the spid_data
+  return {
+    spid_data: {
+      family_name: user.family_name,
+      fiscal_code: user.fiscal_code,
+      name: user.name,
+      spid_email: user.spid_email,
+      spid_mobile_phone: user.spid_mobile_phone
+    }
+  };
+}
 
 /**
  * Converts an existing API profile to a Proxy profile.
@@ -20,44 +35,20 @@ import { GetProfileOKResponse } from "./api_client/getProfileOKResponse";
  * @param {GetProfileOKResponse} from The profile retrieved from the Digital Citizenship API.
  * @param {User} user The user data extracted from SPID.
  */
-export function toAppProfileWithEmail(
+export function toAppProfileWithCDData(
   from: GetProfileOKResponse,
   user: User
-): ProfileWithEmail {
+): Profile {
   return {
-    blocked_inbox_or_channels: from.blockedInboxOrChannels,
-    email: from.email,
-    family_name: user.family_name,
-    fiscal_code: user.fiscal_code,
-    has_profile: true,
-    is_email_set: !!from.email,
-    is_inbox_enabled: from.isInboxEnabled,
-    is_webhook_enabled: from.isWebhookEnabled,
-    name: user.name,
-    preferred_languages: from.preferredLanguages,
-    spid_email: user.spid_email,
-    spid_mobile_phone: user.spid_mobile_phone,
-    version: from.version
-  };
-}
-
-/**
- * Converts an empty API profile to a Proxy profile.
- *
- * @param {User} user The user data extracted from SPID.
- */
-export function toAppProfileWithoutEmail(user: User): ProfileWithoutEmail {
-  return {
-    family_name: user.family_name,
-    fiscal_code: user.fiscal_code,
-    has_profile: false,
-    is_email_set: false,
-    is_inbox_enabled: false,
-    is_webhook_enabled: false,
-    name: user.name,
-    spid_email: user.spid_email,
-    spid_mobile_phone: user.spid_mobile_phone,
-    version: 0 as Version
+    ...toProfileWithoutCDData(user),
+    cd_data: {
+      blocked_inbox_or_channels: from.blockedInboxOrChannels,
+      email: from.email,
+      is_inbox_enabled: from.isInboxEnabled,
+      is_webhook_enabled: from.isWebhookEnabled,
+      preferred_languages: from.preferredLanguages,
+      version: from.version
+    }
   };
 }
 


### PR DESCRIPTION
A single Profile type with required spid_data (family_name, ....) and optional cd_data (inbox, ...).

WIP because i need to have the new IDP (testenv2) running locally to test all works.