### PR TITLE
Return profile fields that are either from a temporary SPID profile or from an initialized API profile

### DIFF
--- a/api_proxy.yaml
+++ b/api_proxy.yaml
@@ -172,8 +172,8 @@ paths:
           description: Found.
           schema:
             allOf:
-              - $ref: "#/definitions/ProfileWithEmail"
-              - $ref: "#/definitions/ProfileWithoutEmail"
+              - $ref: "#/definitions/InitializedProfile"
+              - $ref: "#/definitions/AuthenticatedProfile"
           examples:
             application/json:
               family_name: "Rossi"
@@ -212,7 +212,7 @@ paths:
         '200':
           description: Profile updated.
           schema:
-            $ref: "#/definitions/ProfileWithEmail"
+            $ref: "#/definitions/InitializedProfile"
           examples:
             application/json:
               email: foobar@example.com
@@ -488,13 +488,11 @@ definitions:
     required:
       - platform
       - pushChannel
-  ProfileWithEmail:
+  InitializedProfile:
     type: object
-    title: Profile with wmail
-    description: Describes the user's profile.
+    title: Initialized profile
+    description: Describes the user's profile after it has been stored in the Profile API.
     properties:
-      blocked_inbox_or_channels:
-        $ref: "#/definitions/BlockedInboxOrChannels"
       email:
         $ref: '#/definitions/EmailAddress'
       family_name:
@@ -503,8 +501,6 @@ definitions:
         $ref: '#/definitions/FiscalCode'
       has_profile:
         $ref: "#/definitions/HasProfile"
-      is_email_set:
-        $ref: "#/definitions/IsEmailSet"
       is_inbox_enabled:
         $ref: "#/definitions/IsInboxEnabled"
       is_webhook_enabled:
@@ -520,23 +516,24 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/PreferredLanguage'
+      blocked_inbox_or_channels:
+        $ref: "#/definitions/BlockedInboxOrChannels"
       version:
         $ref: '#/definitions/Version'
     required:
       - family_name
       - fiscal_code
       - has_profile
-      - is_email_set
       - is_inbox_enabled
       - is_webhook_enabled
       - name
       - spid_email
       - spid_mobile_phone
       - version
-  ProfileWithoutEmail:
+  AuthenticatedProfile:
     type: object
-    title: Profile without email
-    description: Describes the user's profile.
+    title: Temporary SPID profile
+    description: Describes the user's profile while it's authenticated but not yet stored in the Profile API.
     properties:
       family_name:
         type: string
@@ -544,12 +541,6 @@ definitions:
         $ref: '#/definitions/FiscalCode'
       has_profile:
         $ref: "#/definitions/HasProfile"
-      is_email_set:
-        $ref: "#/definitions/IsEmailSet"
-      is_inbox_enabled:
-        $ref: "#/definitions/IsInboxEnabled"
-      is_webhook_enabled:
-        $ref: "#/definitions/IsWebhookEnabled"
       name:
         type: string
       spid_email:
@@ -557,23 +548,13 @@ definitions:
       spid_mobile_phone:
         type: string
         minLength: 1
-      preferred_languages:
-        type: array
-        items:
-          $ref: '#/definitions/PreferredLanguage'
-      version:
-        $ref: '#/definitions/Version'
     required:
       - family_name
       - fiscal_code
       - has_profile
-      - is_email_set
-      - is_inbox_enabled
-      - is_webhook_enabled
       - name
       - spid_email
       - spid_mobile_phone
-      - version
   PublicSession:
     type: object
     title: User session data

--- a/src/controllers/pagoPAController.ts
+++ b/src/controllers/pagoPAController.ts
@@ -9,8 +9,8 @@ import {
   ResponseSuccessJson
 } from "italia-ts-commons/lib/responses";
 import ProfileService, { profileResponse } from "../services/profileService";
+import { InitializedProfile } from "../types/api/InitializedProfile";
 import { PagoPAUser } from "../types/api/PagoPAUser";
-import { ProfileWithEmail } from "../types/api/ProfileWithEmail";
 import { toHttpError } from "../types/error";
 import { extractUserFromRequest } from "../types/user";
 
@@ -41,7 +41,7 @@ export default class PagoPAController {
     }
 
     const profile = errorOrProfile.value;
-    const maybeCustomEmail = ProfileWithEmail.is(profile)
+    const maybeCustomEmail = InitializedProfile.is(profile)
       ? profile.email
       : undefined;
     const email = maybeCustomEmail ? maybeCustomEmail : profile.spid_email;

--- a/src/controllers/profileController.ts
+++ b/src/controllers/profileController.ts
@@ -12,8 +12,8 @@ import {
   ResponseSuccessJson
 } from "italia-ts-commons/lib/responses";
 import ProfileService, { profileResponse } from "../services/profileService";
-import { ProfileWithEmail } from "../types/api/ProfileWithEmail";
-import { ProfileWithoutEmail } from "../types/api/ProfileWithoutEmail";
+import { AuthenticatedProfile } from "../types/api/AuthenticatedProfile";
+import { InitializedProfile } from "../types/api/InitializedProfile";
 import { toHttpError } from "../types/error";
 import {
   extractUpsertProfileFromRequest,
@@ -34,7 +34,7 @@ export default class ProfileController {
    */
   public async getProfile(
     req: express.Request
-  ): Promise<profileResponse<ProfileWithoutEmail | ProfileWithEmail>> {
+  ): Promise<profileResponse<AuthenticatedProfile | InitializedProfile>> {
     const errorOrUser = extractUserFromRequest(req);
 
     if (isLeft(errorOrUser)) {
@@ -61,7 +61,7 @@ export default class ProfileController {
    */
   public async upsertProfile(
     req: express.Request
-  ): Promise<profileResponseWithValidationError<ProfileWithEmail>> {
+  ): Promise<profileResponseWithValidationError<InitializedProfile>> {
     const errorOrUser = extractUserFromRequest(req);
 
     if (isLeft(errorOrUser)) {

--- a/src/services/__tests__/profileService.test.ts
+++ b/src/services/__tests__/profileService.test.ts
@@ -36,12 +36,12 @@ const validApiProfileResponse = {
     status: 200
   }
 };
-const proxyProfileWithEmailResponse = {
+const proxyInitializedProfileResponse = {
+  blocked_inbox_or_channels: undefined,
   email: aValidAPIEmail,
   family_name: "Lusso",
   fiscal_code: "XUZTCT88A51Y311X",
   has_profile: true,
-  is_email_set: true,
   is_inbox_enabled: true,
   is_webhook_enabled: true,
   name: "Luca",
@@ -50,17 +50,13 @@ const proxyProfileWithEmailResponse = {
   spid_mobile_phone: "3222222222222",
   version: 42
 };
-const proxyProfileWithoutEmailResponse = {
+const proxyAuthenticatedProfileResponse = {
   family_name: "Lusso",
   fiscal_code: aValidFiscalCode,
   has_profile: false,
-  is_email_set: false,
-  is_inbox_enabled: false,
-  is_webhook_enabled: false,
   name: "Luca",
   spid_email: aValidSPIDEmail,
-  spid_mobile_phone: "3222222222222",
-  version: 0
+  spid_mobile_phone: "3222222222222"
 };
 const proxyUpsertRequest = {
   email: aValidAPIEmail,
@@ -140,7 +136,7 @@ describe("ProfileService#getProfile", () => {
 
     expect(mockGetClient).toHaveBeenCalledWith(mockedUser.fiscal_code);
     expect(mockGetProfile).toHaveBeenCalledWith();
-    expect(res).toEqual(right(proxyProfileWithEmailResponse));
+    expect(res).toEqual(right(proxyInitializedProfileResponse));
   });
 
   it("returns a default user profile if the response from the API is not found", async () => {
@@ -154,7 +150,7 @@ describe("ProfileService#getProfile", () => {
 
     expect(mockGetClient).toHaveBeenCalledWith(mockedUser.fiscal_code);
     expect(mockGetProfile).toHaveBeenCalledWith();
-    expect(res).toEqual(right(proxyProfileWithoutEmailResponse));
+    expect(res).toEqual(right(proxyAuthenticatedProfileResponse));
   });
 
   it("returns an error if the API returns an error", async () => {
@@ -190,7 +186,7 @@ describe("ProfileService#upsertProfile", () => {
 
     expect(mockGetClient).toHaveBeenCalledWith(mockedUser.fiscal_code);
     expect(mockUpsertProfile).toHaveBeenCalledWith(ApiProfileUpsertRequest);
-    expect(res).toEqual(right(proxyProfileWithEmailResponse));
+    expect(res).toEqual(right(proxyInitializedProfileResponse));
   });
 
   it("fails to create a new user profile to the API", async () => {

--- a/src/services/profileService.ts
+++ b/src/services/profileService.ts
@@ -11,17 +11,14 @@ import {
   IResponseSuccessJson
 } from "italia-ts-commons/lib/responses";
 import { DigitalCitizenshipAPIUpsertProfileOptionalParams } from "../clients/api/models";
+import { AuthenticatedProfile } from "../types/api/AuthenticatedProfile";
+import { InitializedProfile } from "../types/api/InitializedProfile";
 import { ProblemJson } from "../types/api/ProblemJson";
-import { ProfileWithEmail } from "../types/api/ProfileWithEmail";
-import { ProfileWithoutEmail } from "../types/api/ProfileWithoutEmail";
 import { ExtendedProfile } from "../types/api_client/extendedProfile";
 import { GetProfileOKResponse } from "../types/api_client/getProfileOKResponse";
 import { UpsertProfileOKResponse } from "../types/api_client/upsertProfileOKResponse";
 import { internalError, ServiceError } from "../types/error";
-import {
-  toAppProfileWithEmail,
-  toAppProfileWithoutEmail
-} from "../types/profile";
+import { toAuthenticatedProfile, toInitializedProfile } from "../types/profile";
 import { User } from "../types/user";
 import { log } from "../utils/logger";
 import SimpleHttpOperationResponse from "../utils/simpleResponse";
@@ -43,7 +40,7 @@ export default class ProfileService {
    */
   public async getProfile(
     user: User
-  ): Promise<Either<ServiceError, ProfileWithoutEmail | ProfileWithEmail>> {
+  ): Promise<Either<ServiceError, AuthenticatedProfile | InitializedProfile>> {
     const response = await this.apiClient
       .getClient(user.fiscal_code)
       .getProfileWithHttpOperationResponse();
@@ -66,7 +63,7 @@ export default class ProfileService {
         // If the profile doesn't exists on the API we still
         // return 200 to the App with the information we have
         // retrieved from SPID.
-        return right(toAppProfileWithoutEmail(user));
+        return right(toAuthenticatedProfile(user));
       } else {
         return left(internalError(profileErrorOnApiError));
       }
@@ -84,7 +81,7 @@ export default class ProfileService {
     }
 
     const apiProfile = errorOrApiProfile.value;
-    return right(toAppProfileWithEmail(apiProfile, user));
+    return right(toInitializedProfile(apiProfile, user));
   }
 
   /**
@@ -93,7 +90,7 @@ export default class ProfileService {
   public async upsertProfile(
     user: User,
     upsertProfile: ExtendedProfile
-  ): Promise<Either<ServiceError, ProfileWithEmail>> {
+  ): Promise<Either<ServiceError, InitializedProfile>> {
     const upsertOptions: DigitalCitizenshipAPIUpsertProfileOptionalParams = {
       body: upsertProfile
     };
@@ -130,6 +127,6 @@ export default class ProfileService {
     }
 
     const apiProfile = errorOrApiProfile.value;
-    return right(toAppProfileWithEmail(apiProfile, user));
+    return right(toInitializedProfile(apiProfile, user));
   }
 }

--- a/src/types/__tests__/profile.test.ts
+++ b/src/types/__tests__/profile.test.ts
@@ -18,8 +18,8 @@ import { Version } from "../api/Version";
 import { GetProfileOKResponse } from "../api_client/getProfileOKResponse";
 import {
   extractUpsertProfileFromRequest,
-  toAppProfileWithEmail,
-  toAppProfileWithoutEmail
+  toAuthenticatedProfile,
+  toInitializedProfile
 } from "../profile";
 import { SessionToken, WalletToken } from "../token";
 import { User } from "../user";
@@ -69,7 +69,7 @@ describe("profile type", () => {
   /*test case: Converts an existing API profile to a Proxy profile using user profile with email from Digital Citzen API and SPID*/
   it("should get an app Proxy profile user profile with email from Digital Citzen API and SPID", async () => {
     // return app Proxy Profile.
-    const userData = toAppProfileWithEmail(
+    const userData = toInitializedProfile(
       mockedGetProfileOKResponse, // from
       mockedUser // user
     );
@@ -78,7 +78,6 @@ describe("profile type", () => {
     expect(userData.family_name).toBe(mockedUser.family_name);
     expect(userData.fiscal_code).toBe(mockedUser.fiscal_code);
     expect(userData.has_profile).toBeTruthy();
-    expect(userData.is_email_set).toBeTruthy();
     expect(userData.is_inbox_enabled).toBe(
       mockedGetProfileOKResponse.isInboxEnabled
     );
@@ -96,17 +95,15 @@ describe("profile type", () => {
   /*test case: Converts an empty API profile to a Proxy profile using only the user data extracted from SPID.*/
   it("should get an app Proxy profile without email from user data extracted from SPID", async () => {
     // validate SpidUser. Return right.
-    const userData = toAppProfileWithoutEmail(
+    const userData = toAuthenticatedProfile(
       mockedUser // user
     );
 
     expect(userData.family_name).toBe(mockedUser.family_name);
     expect(userData.fiscal_code).toBe(mockedUser.fiscal_code);
     expect(userData.has_profile).toBeFalsy();
-    expect(userData.is_email_set).toBeFalsy();
 
     expect(userData.spid_email).toBe(mockedUser.spid_email);
-    expect(userData.version).toBe(0);
   });
 
   /*test case: Extracts a user profile from the body of a request.*/

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -7,10 +7,9 @@ import { Either } from "fp-ts/lib/Either";
 import { User } from "./user";
 
 import * as express from "express";
+import { AuthenticatedProfile } from "./api/AuthenticatedProfile";
 import { ExtendedProfile as proxyExtendedProfile } from "./api/ExtendedProfile";
-import { ProfileWithEmail } from "./api/ProfileWithEmail";
-import { ProfileWithoutEmail } from "./api/ProfileWithoutEmail";
-import { Version } from "./api/Version";
+import { InitializedProfile } from "./api/InitializedProfile";
 import { ExtendedProfile as apiExtendedProfile } from "./api_client/extendedProfile";
 import { GetProfileOKResponse } from "./api_client/getProfileOKResponse";
 
@@ -20,17 +19,16 @@ import { GetProfileOKResponse } from "./api_client/getProfileOKResponse";
  * @param {GetProfileOKResponse} from The profile retrieved from the Digital Citizenship API.
  * @param {User} user The user data extracted from SPID.
  */
-export function toAppProfileWithEmail(
+export function toInitializedProfile(
   from: GetProfileOKResponse,
   user: User
-): ProfileWithEmail {
+): InitializedProfile {
   return {
     blocked_inbox_or_channels: from.blockedInboxOrChannels,
     email: from.email,
     family_name: user.family_name,
     fiscal_code: user.fiscal_code,
     has_profile: true,
-    is_email_set: !!from.email,
     is_inbox_enabled: from.isInboxEnabled,
     is_webhook_enabled: from.isWebhookEnabled,
     name: user.name,
@@ -46,18 +44,14 @@ export function toAppProfileWithEmail(
  *
  * @param {User} user The user data extracted from SPID.
  */
-export function toAppProfileWithoutEmail(user: User): ProfileWithoutEmail {
+export function toAuthenticatedProfile(user: User): AuthenticatedProfile {
   return {
     family_name: user.family_name,
     fiscal_code: user.fiscal_code,
     has_profile: false,
-    is_email_set: false,
-    is_inbox_enabled: false,
-    is_webhook_enabled: false,
     name: user.name,
     spid_email: user.spid_email,
-    spid_mobile_phone: user.spid_mobile_phone,
-    version: 0 as Version
+    spid_mobile_phone: user.spid_mobile_phone
   };
 }
 


### PR DESCRIPTION
The previous `ProfileWithoutEmail` / `ProfileWithEmail` types created confusion on which attributes were actually coming from the APIs - in this PR I'm changing the names of the types and removing the API fields from the temporary SPID profile.